### PR TITLE
Change config param to class.

### DIFF
--- a/celerytest/__init__.py
+++ b/celerytest/__init__.py
@@ -1,13 +1,14 @@
-from config import CELERY_TEST_BACKEND_CONFIG, CELERY_TEST_CONFIG
+from config import CELERY_TEST_CONFIG, CELERY_TEST_CONFIG_MEMORY
 from worker import CeleryWorkerThread
 
-def setup_celery_worker(app, config='memory', concurrency=1):
-    backend_conf = CELERY_TEST_BACKEND_CONFIG[config]
-    conf = dict(CELERY_TEST_CONFIG.__dict__.items() + backend_conf.__dict__.items())
+
+def setup_celery_worker(app, config=CELERY_TEST_CONFIG_MEMORY, concurrency=1):
+    conf = dict(CELERY_TEST_CONFIG.__dict__.items() + config.__dict__.items())
     conf['CELERYD_CONCURRENCY'] = concurrency
     app.config_from_object(conf)
 
-def start_celery_worker(app, config='memory', concurrency=1):
+
+def start_celery_worker(app, config=CELERY_TEST_CONFIG_MEMORY, concurrency=1):
     setup_celery_worker(app, config=config, concurrency=concurrency)
 
     worker = CeleryWorkerThread(app)

--- a/celerytest/config.py
+++ b/celerytest/config.py
@@ -18,8 +18,3 @@ class CELERY_TEST_CONFIG_AMQP(object):
     CELERY_DEFAULT_EXCHANGE = 'test_default'
     CELERY_RESULT_EXCHANGE = 'test_celeryresults'
     CELERY_BROADCAST_QUEUE = 'test_celeryctl'
-
-CELERY_TEST_BACKEND_CONFIG = {
-    'memory': CELERY_TEST_CONFIG_MEMORY,
-    'amqp': CELERY_TEST_CONFIG_AMQP
-}

--- a/celerytest/testcase.py
+++ b/celerytest/testcase.py
@@ -1,4 +1,6 @@
 from . import start_celery_worker
+from celerytest.config import CELERY_TEST_CONFIG_MEMORY
+
 
 class CeleryTestCaseMixin(object):
     '''
@@ -7,16 +9,17 @@ class CeleryTestCaseMixin(object):
     Worker is started and stopped on class setup/teardown.
     Use self.worker.idle.wait() to make sure tasks have stopped executing.
     '''
-    celery_config = 'memory'
+    celery_config = CELERY_TEST_CONFIG_MEMORY
     celery_app = None
     celery_concurrency = 1
     celery_share_worker = True
 
     @classmethod
     def start_worker(cls):
-        return start_celery_worker(cls.celery_app, 
-            config=cls.celery_config, concurrency=cls.celery_concurrency)
-    
+        return start_celery_worker(cls.celery_app,
+                                   config=cls.celery_config,
+                                   concurrency=cls.celery_concurrency)
+
     @classmethod
     def setup_class(cls):
         cls.worker = cls.start_worker()


### PR DESCRIPTION
Change the config param in start_celery_worker and setup_celery_worker
to a config class.
This allow to set specific configuration for the worker, like the uri
for the broker, or which queues to consume.
